### PR TITLE
Generate UI schema lazily

### DIFF
--- a/review/src/ReviewConfig.elm
+++ b/review/src/ReviewConfig.elm
@@ -87,4 +87,5 @@ config =
         ]
         |> NoInconsistentAliases.noMissingAliases
         |> NoInconsistentAliases.rule
+    , Simplify.rule Simplify.defaults
     ]

--- a/src/Form.elm
+++ b/src/Form.elm
@@ -55,7 +55,7 @@ should be documented.
 init : UI.DefOptions -> String -> Schema -> Maybe UiSchema -> Form
 init options id schema uiSchema =
     { schema = schema
-    , uiSchema = Maybe.withDefaultLazy (always <| generateUiSchema schema) uiSchema
+    , uiSchema = Maybe.withDefaultLazy (\() -> generateUiSchema schema) uiSchema
     , uiSchemaIsGenerated = uiSchema == Nothing
     , state = Form.State.initState id (defaultValue schema) (validate schema)
     , defaultOptions = options
@@ -133,7 +133,7 @@ Form data is preserved.
 setUiSchema : Maybe UiSchema -> Form -> Form
 setUiSchema uiSchema form =
     { form
-        | uiSchema = Maybe.withDefaultLazy (always <| generateUiSchema form.schema) uiSchema
+        | uiSchema = Maybe.withDefaultLazy (\() -> generateUiSchema form.schema) uiSchema
         , uiSchemaIsGenerated = uiSchema == Nothing
     }
 

--- a/src/Form.elm
+++ b/src/Form.elm
@@ -195,4 +195,4 @@ Empty list is returned if the form contains no errors.
 -}
 getErrors : Form -> List ( Pointer, Error.ErrorValue )
 getErrors form =
-    List.map (\( p, e ) -> ( p, e )) form.state.errors
+    form.state.errors

--- a/src/Form/Widget/Generate.elm
+++ b/src/Form/Widget/Generate.elm
@@ -156,7 +156,7 @@ controlWidget defaultOptions uiState wholeSchema subSchema control form =
         controlOptions =
             let
                 disabled =
-                    defOptions.readonly == True || uiState.disabled
+                    defOptions.readonly || uiState.disabled
 
                 dispRequired =
                     isRequired wholeSchema control.scope && not defOptions.hideRequiredAsterisk
@@ -271,7 +271,7 @@ textLikeControl fieldType fieldValue pointer elementId defOptions subSchema =
                 , onChange = Input pointer << fromFieldInput fieldType
                 }
 
-    else if defOptions.slider == True then
+    else if defOptions.slider then
         let
             step =
                 Maybe.withDefault 1.0 subSchema.multipleOf
@@ -363,7 +363,7 @@ isRequired wholeSchema pointer =
         isPropertyRequired =
             case ( parentSchema, List.last pointer ) of
                 ( Just schema, Just prop ) ->
-                    List.any ((==) prop) (Maybe.withDefault [] schema.required)
+                    List.member prop (Maybe.withDefault [] schema.required)
 
                 _ ->
                     False

--- a/src/Validation.elm
+++ b/src/Validation.elm
@@ -1,10 +1,8 @@
 module Validation exposing
     ( Validation
-    , andMap
     , error
     , fail
     , isOk
-    , map
     , mapErrorPointers
     , oneOf
     , succeed


### PR DESCRIPTION
Hi folks :wave: 

I took a look at the source code and found some tiny ways to improve the code.

- Better use of `Maybe.withDefaultLazy`: While Maybe.withDefaultLazy calls the function only if necessary, the value to compute lazily is already created when passed to Basics.always. Putting the computation in a lambda gets the expected benefits.
- There was some unnecessary `List.map`ping
- There were some unused exported functions
- I also enabled the `elm-review` `Simplify` rule which was somehow not part of the list of rules, and applied the simplifications it found.

Feel free to take what you like and leave out the rest.